### PR TITLE
Add section about problems with long running workers

### DIFF
--- a/docs/5.Workers.md
+++ b/docs/5.Workers.md
@@ -18,7 +18,7 @@ contains inside the `processQueue()` method. However, there are reasons to cance
 continue. PHP is not the best language for creating infinite running scripts.
 
 It is wise to abort the script frequently, for example after x number of cycles in the `while` loop. Be sure to have 
-some system that restart the worker (e. g. supervisord see [7. Worker management](7.WorkerManagement.md))
+some system that restart the worker (e. g. systemd or supervisord see [7. Worker management](7.WorkerManagement.md))
 
 Various build-in strategies (['see 6.Events'](6.Events.md)) are used to decide if the worker should exit. These
 strategies are aggregate listeners that hook into events the worker dispatches. A listener (to 'process.queue' or 

--- a/docs/5.Workers.md
+++ b/docs/5.Workers.md
@@ -13,15 +13,37 @@ for the different queue implementations.
 Worker stop conditions
 ----------------------
 
-The worker will be a long running call, due to the `while(...){ /*...*/ }` loop it
+The worker will be a long running call, due to the `while (...) { /*...*/ }` loop it
 contains inside the `processQueue()` method. However, there are reasons to cancel the loop and stop the worker to
 continue. PHP is not the best language for creating infinite running scripts.
 
-It is wise to abort the script frequently, for example after x number of cycles in the `while` loop. 
+It is wise to abort the script frequently, for example after x number of cycles in the `while` loop. Be sure to have 
+some system that restart the worker (e. g. supervisord see [7. Worker management](7.WorkerManagement.md))
 
 Various build-in strategies (['see 6.Events'](6.Events.md)) are used to decide if the worker should exit. These
-strategies are aggregate listeners that hook into events the worker dispatches. A listener (to 'process.queue' or 'process.idle') may shortcut the event flow simply be returning a `ExitWorkerLoopResult::withReason('a reason')`. The
+strategies are aggregate listeners that hook into events the worker dispatches. A listener (to 'process.queue' or 
+'process.idle') may shortcut the event flow simply be returning a `ExitWorkerLoopResult::withReason('a reason')`. The
 worker will inspect the response collection.
+
+If you want to run a worker for a long time (or to determine the frequency of the restart) you have to take into account
+all open connections to external systems.
+
+Some examples:
+- the database server (e. g. MySQL) may close the connection
+  - possible error message: "MySQL has gone away"
+  - see "connect_timeout", "wait_timeout" and "interactive-timeout" options in MySQL, they all default to 8 hours
+  - You can use [BsbDoctrineReconnect](https://github.com/bushbaby/BsbDoctrineReconnect) to automatically reconnect doctrine
+- SMTP servers are known to close connections if they are open / idle too long
+  - see [Postfix: smtp_connection_reuse_time_limit](http://www.postfix.org/postconf.5.html#smtp_connection_reuse_time_limit), default is 5 minutes
+
+In order to fix these problems you could stop reusing the same connection and open/close a new connection for each 
+new job. This will increase the overhead significantly, which may be inaccaptable (especially under high pressure situations with an high amount 
+of jobs requring external connections).
+
+If you want to keep reusing the connection with long running workers you may need some ability to auto-reconnect these 
+external system.
+
+Our suggestion is using auto-reconnecting external connections and a time-based restart of the worker.
 
 Command line utility
 --------------------

--- a/docs/5.Workers.md
+++ b/docs/5.Workers.md
@@ -37,8 +37,8 @@ Some examples:
   - see [Postfix: smtp_connection_reuse_time_limit](http://www.postfix.org/postconf.5.html#smtp_connection_reuse_time_limit), default is 5 minutes
 
 In order to fix these problems you could stop reusing the same connection and open/close a new connection for each 
-new job. This will increase the overhead significantly, which may be inaccaptable (especially under high pressure situations with an high amount 
-of jobs requring external connections).
+new job. This will increase the overhead significantly, which may be inaccaptable (especially under high pressure 
+situations with a number of jobs requring external connections).
 
 If you want to keep reusing the connection with long running workers you may need some ability to auto-reconnect these 
 external system.

--- a/docs/7.WorkerManagement.md
+++ b/docs/7.WorkerManagement.md
@@ -8,8 +8,11 @@ For Linux there is a system called [supervisord](http://supervisord.org). Superv
 them automatically and restarts them when they are stopped. This part of the SlmQueue documentation does not fully
 explain all features of supervisord, but it gives a kickstart for users who are in need of worker management.
 
-Basic configuration
--------------------
+If you prefer to use [systemd](https://wiki.freedesktop.org/www/Software/systemd/) instead skip down to the 
+systemd sections.
+
+supervisord: Basic configuration
+--------------------------------
 
 Supervisord has a configuration file under `/etc/supervisord/supervisord.conf`. There you define some basic settings, 
 for example logging. Under `[unix_http_server]` and `[supervisorctl]` you have to define some required fields as well:
@@ -28,8 +31,8 @@ file             = /tmp/supervisor.sock
 serverurl        = unix:///tmp/supervisor.sock
 ```
 
-Worker configuration
---------------------
+supervisord: Worker configuration
+---------------------------------
 
 In supervisord, every process "group" it manages is sectioned under a `[program:x]` key. Here, `x` is the name of the 
 program you want to manage. For using SlmQueue in your application, you might want to choose `my-app` as an appropriate
@@ -54,8 +57,8 @@ In case of an error or exception, the worker will probably be killed very soon. 
 which occur within 1 second after the process started. If the process is killed within 1 second for 3 consequetive times,
 supervisord stops respwaning the process. This event will be registered in the log of supervisord.
 
-Multiple workers
-----------------
+supervisord: Multiple workers
+-----------------------------
 
 When a large number of jobs are inserted into the queue, you might want to spin up more than one worker. Supervisord is 
 capable of managing more processes of one program, under the key `numprocs`. Because be default, the process name is the
@@ -69,6 +72,124 @@ numprocs     = 3
 process_name = my-app-worker-%(process_num)
 autorestart  = true
 ```
+
+Alternative: systemd
+-----------------------------------
+
+Systemd is a new init system and comes pre-installed in Fedora, RHEL, Debian and their respective derivatives. 
+It can be used to run worker continously with auto-restart and multiple instances.
+
+Define your worker in a service file `/lib/systemd/system/my-app-worker.service`:
+```ini
+[Unit]
+# Description of the service
+Description=MyApp-Worker
+
+# Add some other services / targets that you need before your worker can be started
+# e. g. we need the network, mysql & redis server to work!
+After=network.target mysqld.service redis-server.service
+
+# If you have enabled auto-restarting (see below) systemd will stop restarting this service if it fails too often 
+# Setting StartLimitIntervalSec to 0 disables this behavior.
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+
+# Enable auto-restarting
+Restart=always
+
+# Wait 1 minute to restart the service after its exit
+RestartSec=60
+
+# set the correct user and group for the execution
+User=www-data
+Group=www-data
+
+# You have to insert the correct server-specific directory here!
+ExecStart=/usr/bin/php /var/www/mysite/public/index.php queue beanstalkd
+
+[Install]
+# Start this target after the multi-user.target is reached (if its enabled)
+WantedBy=multi-user.target
+```
+
+You can manage your new service with these commands:
+```bash
+systemctl start   my-app-worker.service
+systemctl status  my-app-worker.service
+systemctl stop    my-app-worker.service
+systemctl restart my-app-worker.service
+ 
+systemctl enable my-app-worker.service # "enables" this service: this mean this service will be started on boot
+```
+
+systemd: using multiple workers
+-------------------------------
+
+If you want to use multiple workers there are some key differences.
+
+Save your service file as `/lib/systemd/system/my-app-worker@.service` (mind the @) using this modified template:
+```ini
+[Unit]
+# Description of the service with the worker ID in it
+Description=MyApp-Worker %i
+
+# If you have enabled auto-restarting (see below) systemd will stop restarting this service if it fails too often 
+# Setting StartLimitIntervalSec to 0 disables this behavior.
+StartLimitIntervalSec=0
+
+# Make this worker a part of my-app.target
+# This means when my-app.target is stopped or restarted, this worker will be stopped or restarted too. 
+# But if this worker is stopped or restarted, it will not affect each other.
+PartOf=my-app.target
+
+[Service]
+Type=simple
+
+# Enable auto-restarting
+Restart=always
+
+# Wait 1 minute to restart the service after its exit
+RestartSec=60
+
+# set the correct user and group for the execution
+User=www-data
+Group=www-data
+
+# You have to insert the correct server-specific directory here!
+ExecStart=/usr/bin/php /var/www/mysite/public/index.php queue beanstalkd
+```
+
+Add a target file `/lib/systemd/system/my-app.target`:
+```ini
+[Unit]
+# Add some other services / targets that you need before your worker can be started
+# e. g. we need the network, mysql & redis server to work!
+After=network.target mysqld.service redis-server.service
+
+# This target want the workers to be started
+# Add as many as you like
+Wants=my-app-worker@1.service my-app-worker@2.service my-app-worker@3.service
+
+[Install]
+# Start this target after the multi-user.target is reached (if its enabled)
+WantedBy=multi-user.target
+```
+
+Use these commands to manage your workers and the whole app:
+```bash
+systemctl start   my-app-worker@1.service
+systemctl status  my-app-worker@1.service
+systemctl stop    my-app-worker@1.service
+systemctl restart my-app-worker@1.service
+# same with workers 2 and 3
+ 
+# "enables" this target: this mean this target will be started on boot (and all workers in it too):
+systemctl enable my-app.target 
+```
+
+More information can be found at [gunes.io: systemd vs supervisord](https://www.gunes.io/2017/08/24/systemd-vs-supervisor).
 
 Navigation
 ----------

--- a/docs/7.WorkerManagement.md
+++ b/docs/7.WorkerManagement.md
@@ -179,12 +179,21 @@ WantedBy=multi-user.target
 
 Use these commands to manage your workers and the whole app:
 ```bash
+# Start / stop one worker:
 systemctl start   my-app-worker@1.service
 systemctl status  my-app-worker@1.service
 systemctl stop    my-app-worker@1.service
 systemctl restart my-app-worker@1.service
 # same with workers 2 and 3
- 
+
+# Start / stop all workers at the same time: 
+systemctl start my-app.target
+systemctl stop my-app.target
+systemctl restart my-app.target
+
+# Shows all workers and their status
+systemctl list-dependencies my-app.target
+
 # "enables" this target: this mean this target will be started on boot (and all workers in it too):
 systemctl enable my-app.target 
 ```


### PR DESCRIPTION
Adds a section about problems with long running workers.

See https://github.com/JouwWeb/SlmQueue/issues/177 and https://github.com/JouwWeb/SlmQueue/issues/130 for further discussions.

@roelvanduijnhoven 
Is the suggestion OK?
The WorkerManagement docs are specialized in supervisord. I'd like to add a section for using systemd instead since a lot of system have it pre-installed. 