### PR TITLE
Prepare for a release that does not allow return status codes of jobs

### DIFF
--- a/src/Job/JobInterface.php
+++ b/src/Job/JobInterface.php
@@ -27,7 +27,13 @@ interface JobInterface extends MessageInterface
     public function getId();
 
     /**
-     * Execute the job
+     * Execute the job.
+     *
+     * TODO Deprecate the usage of int as return value, and introduce exceptions as part of the API to signal a
+     *   non-success result.
+     *
+     * @return void|?int Omitting return value, or returning `null` means the job was successful. Otherwise the int
+     *   returned will represent.
      */
-    public function execute(): ?int;
+    public function execute();
 }

--- a/tests/Asset/JobWithNoReturnType.php
+++ b/tests/Asset/JobWithNoReturnType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SlmQueueTest\Asset;
+
+use SlmQueue\Job\AbstractJob;
+
+class JobWithNoReturnType extends AbstractJob
+{
+    public function execute()
+    {
+        // Just set some stupid metadata
+        $this->setMetadata('foo', 'bar');
+
+        return 999;
+    }
+}

--- a/tests/Asset/JobWithVoidReturnType.php
+++ b/tests/Asset/JobWithVoidReturnType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SlmQueueTest\Asset;
+
+use SlmQueue\Job\AbstractJob;
+
+class JobWithVoidReturnType extends AbstractJob
+{
+    public function execute()
+    {
+        // Just set some stupid metadata
+        $this->setMetadata('foo', 'bar');
+
+        return 999;
+    }
+}


### PR DESCRIPTION
There are two problems with the introduction of the `?int` type of jobs:

- We require each job to finish with a `return ..` statement. This really is no improvement.
- There is no possibility to communicate anything more than the result. We rather use Exceptions for those cases, and allow for more metadata using them. Much like SlmQueueDoctrine does this.

This PR removes the status code definition as a first step. 

We can release this in a minor release, because SlmQueueDoctrine or other users can still run implement the `JobInterface` _with_ the more strict return type `?int`.