### PR TITLE
PHP 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
         - DEPENDENCIES=""
         - EXECUTE_CS_CHECK=true
         - TEST_COVERAGE=true
+    - php: 8.0
+      env:
+        - DEPENDENCIES="--ignore-platform-reqs"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env:
-        - DEPENDENCIES="--prefer-lowest"
-    - php: 7.2
-      env:
-        - DEPENDENCIES=""
     - php: 7.3
       env:
         - DEPENDENCIES="--prefer-lowest"

--- a/composer.json
+++ b/composer.json
@@ -32,23 +32,25 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "laminas/laminas-eventmanager": "^3.2.1",
-        "laminas/laminas-servicemanager": "^3.3.1",
-        "laminas/laminas-stdlib": "^3.2"
+        "php": "^7.2 || 8.0",
+        "laminas/laminas-eventmanager": "^3.3",
+        "laminas/laminas-router": "^3.4",
+        "laminas/laminas-servicemanager": "^3.6",
+        "laminas/laminas-stdlib": "^3.3"
     },
     "require-dev": {
-        "laminas/laminas-mvc": "^2.7.13",
-        "laminas/laminas-modulemanager": "^2.8.3",
-        "laminas/laminas-view": "^2.7",
-        "laminas/laminas-serializer": "^2.9.1",
-        "laminas/laminas-log": "^2.11",
-        "laminas/laminas-i18n": "^2.8",
+        "laminas/laminas-mvc": "^3.2",
+        "laminas/laminas-modulemanager": "^2.10",
+        "laminas/laminas-view": "^2.12",
+        "laminas/laminas-serializer": "^2.10.1",
+        "laminas/laminas-log": "^2.13",
+        "laminas/laminas-i18n": "^2.11",
         "laminas/laminas-console": "^2.7",
-        "laminas/laminas-config": "^3.2",
-        "phpunit/phpunit": "^8.5",
+        "laminas/laminas-mvc-console": "^1.3",
+        "laminas/laminas-config": "^3.4",
+        "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.5",
-        "php-coveralls/php-coveralls": "^2.0"
+        "php-coveralls/php-coveralls": "^2.4"
     },
     "suggest": {
         "slm/queue-sqs": "If you are using Amazon SQS",

--- a/tests/Controller/AbstractControllerTest.php
+++ b/tests/Controller/AbstractControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace SlmQueueTest\Controller;
 
-use Laminas\Mvc\Router\RouteMatch;
+use Laminas\Router\RouteMatch;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;

--- a/tests/TestConfiguration.php.dist
+++ b/tests/TestConfiguration.php.dist
@@ -18,7 +18,8 @@
  */
 return array(
     'modules' => array(
-        'SlmQueue'
+        'SlmQueue',
+        'Laminas\Mvc\Console',
     ),
     'module_listener_options' => array(
         'config_glob_paths' => array(


### PR DESCRIPTION
Added unit test runs on PHP8 and changed composer.json requirements accordingly.

What else should be done:
* migrate `laminas/laminas-console` commands to `laminas/laminas-cli` - like commands