### PR TITLE
Remove remnants of log job strategy

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -11,10 +11,8 @@ use SlmQueue\Job\JobPluginManager;
 use SlmQueue\Queue\QueuePluginManager;
 use SlmQueue\Strategy\AttachQueueListenersStrategy;
 use SlmQueue\Strategy\Factory\AttachQueueListenersStrategyFactory;
-use SlmQueue\Strategy\Factory\LogJobStrategyFactory;
 use SlmQueue\Strategy\FileWatchStrategy;
 use SlmQueue\Strategy\InterruptStrategy;
-use SlmQueue\Strategy\LogJobStrategy;
 use SlmQueue\Strategy\MaxMemoryStrategy;
 use SlmQueue\Strategy\MaxPollingFrequencyStrategy;
 use SlmQueue\Strategy\MaxRunsStrategy;
@@ -100,7 +98,6 @@ return [
             ],
             'factories' => [
                 AttachQueueListenersStrategy::class => AttachQueueListenersStrategyFactory::class,
-                LogJobStrategy::class => LogJobStrategyFactory::class,
             ],
         ],
     ],

--- a/config/slm_queue.global.php.dist
+++ b/config/slm_queue.global.php.dist
@@ -5,7 +5,6 @@
  * forget to remove the .dist extension from the file), and configure it as you want
  */
 
-use SlmQueue\Strategy\LogJobStrategy;
 use SlmQueue\Strategy\MaxMemoryStrategy;
 use SlmQueue\Strategy\ProcessQueueStrategy;
 
@@ -64,7 +63,7 @@ return [
          *
          * 'strategy_manager' => [
          *    'factories' => [
-         *        LogJobStrategy::class => 'MyVeryOwn\LogJobStrategyFactory',
+         *        MyVeryOwn\LogJobStrategy::class => 'MyVeryOwn\LogJobStrategyFactory',
          *    ]
          * ],
          */

--- a/docs/6.Events.md
+++ b/docs/6.Events.md
@@ -329,15 +329,6 @@ listens to:
 
 This strategy is enabled by default for all queue's.
 
-#### LogJobStrategy
-
-Simple outputs to the console a when it begin executing a job and when it is done.
-
-listens to:
-
- - `process.job` event at priority 1000
- - `process.job` event at priority -1000
-
 #### MaxMemoryStrategy
 
 The MaxMemoryStrategy will measure the amount of memory allocated to PHP after each processed job. It will request to


### PR DESCRIPTION
LogJobStrategy was removed when releasing v3.0.0, but was left in configuration and documentation. 
Just a PR to clean up